### PR TITLE
fix(ws): Songbird would fail if it could not deserialize ws payload. (s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.3.2] - 2023-04-09
+
+This patch release fixes a WS disconnection that would occur when receiving a
+new opcode, which was happening due to Discord sending such an opcode upon
+connecting to a voice channel.
+
+Thanks to the following for their contributions:
+
+- [@Erk-]
+- [@FelixMcFelix]
+
+### Fixed
+
+- [gateway] Songbird would fail if it could not deserialize ws payload ([@Erk-]) [c:752cae7]
+- [docs] Fix compilation due to ambiguous reference ([@FelixMcFelix]) [c:e5d3feb]
+
 ## [0.3.1] — 2023-03-02
 
 This patch release applies some minor fixes, while correcting documentation errors and adjusting some organisaation in the repository.
@@ -420,6 +436,7 @@ We'd also like to thank all users who have contributed to this module in the pas
 - [driver] Handle Voice close codes, prevent Songbird spinning WS threads (#1068) ([@FelixMcFelix]) [c:26c9c91]
 
 <!-- COMPARISONS -->
+[0.3.2]: https://github.com/serenity-rs/songbird/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/serenity-rs/songbird/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/serenity-rs/songbird/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/serenity-rs/songbird/compare/v0.2.1...v0.2.2
@@ -483,6 +500,8 @@ We'd also like to thank all users who have contributed to this module in the pas
 [@wlcx]: https://github.com/wlcx
 
 <!-- COMMITS -->
+[c:e5d3feb]: https://github.com/serenity-rs/songbird/commit/e5d3febb7bfbc6b4b98af3dbf312c23528307544
+[c:752cae7]: https://github.com/serenity-rs/songbird/commit/752cae7a09b25f69ffac110ca3ce4c841d1ec99b
 [c:eedab8f]: https://github.com/serenity-rs/songbird/commit/eedab8f69d1c17125971e290ee8a50fc1adcdffc
 [c:d6c82f5]: https://github.com/serenity-rs/songbird/commit/d6c82f52a6ea876d15a9196de1a7f8a12432407b
 [c:39a6f69]: https://github.com/serenity-rs/songbird/commit/39a6f69f2324b89d17d7200905a9737d057c0d7e

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "ISC"
 name = "songbird"
 readme = "README.md"
 repository = "https://github.com/serenity-rs/songbird.git"
-version = "0.3.1"
+version = "0.3.2"
 
 [dependencies]
 derivative = "2"

--- a/src/driver/connection/error.rs
+++ b/src/driver/connection/error.rs
@@ -25,8 +25,6 @@ pub enum Error {
     CryptoModeUnavailable,
     /// An indicator that an endpoint URL was invalid.
     EndpointUrl,
-    /// Discord hello/ready handshake was violated.
-    ExpectedHandshake,
     /// Discord failed to correctly respond to IP discovery.
     IllegalDiscoveryResponse,
     /// Could not parse Discord's view of our IP.
@@ -101,7 +99,6 @@ impl fmt::Display for Error {
             CryptoModeInvalid => write!(f, "server changed negotiated encryption mode"),
             CryptoModeUnavailable => write!(f, "server did not offer chosen encryption mode"),
             EndpointUrl => write!(f, "endpoint URL received from gateway was invalid"),
-            ExpectedHandshake => write!(f, "voice initialisation protocol was violated"),
             IllegalDiscoveryResponse => write!(f, "IP discovery/NAT punching response was invalid"),
             IllegalIp => write!(f, "IP discovery/NAT punching response had bad IP value"),
             Io(e) => e.fmt(f),
@@ -121,7 +118,6 @@ impl StdError for Error {
             Error::CryptoModeInvalid => None,
             Error::CryptoModeUnavailable => None,
             Error::EndpointUrl => None,
-            Error::ExpectedHandshake => None,
             Error::IllegalDiscoveryResponse => None,
             Error::IllegalIp => None,
             Error::Io(e) => e.source(),

--- a/src/driver/connection/mod.rs
+++ b/src/driver/connection/mod.rs
@@ -97,8 +97,6 @@ impl Connection {
                 },
                 other => {
                     debug!("Expected ready/hello; got: {:?}", other);
-
-                    return Err(Error::ExpectedHandshake);
                 },
             }
         }
@@ -280,8 +278,6 @@ impl Connection {
                 },
                 other => {
                     debug!("Expected resumed/hello; got: {:?}", other);
-
-                    return Err(Error::ExpectedHandshake);
                 },
             }
         }

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -23,11 +23,11 @@ pub(crate) use crypto::CryptoState;
 pub use decode_mode::DecodeMode;
 
 #[cfg(feature = "builtin-queue")]
-use crate::tracks::TrackQueue;
+use crate::tracks::{self, TrackQueue};
 use crate::{
     events::EventData,
     input::Input,
-    tracks::{self, Track, TrackHandle},
+    tracks::{Track, TrackHandle},
     Config,
     ConnectionInfo,
     Event,

--- a/src/driver/tasks/ws.rs
+++ b/src/driver/tasks/ws.rs
@@ -86,10 +86,6 @@ impl AuxNetwork {
                 }
                 ws_msg = self.ws_client.recv_json_no_timeout(), if !self.dont_send => {
                     ws_error = match ws_msg {
-                        Err(WsError::Json(e)) => {
-                            debug!("Unexpected JSON {:?}.", e);
-                            false
-                        },
                         Err(e) => {
                             should_reconnect = ws_error_is_not_final(&e);
                             ws_reason = Some((&e).into());

--- a/src/events/context/data/disconnect.rs
+++ b/src/events/context/data/disconnect.rs
@@ -91,7 +91,6 @@ impl From<&ConnectionError> for DisconnectReason {
             CryptoModeInvalid
             | CryptoModeUnavailable
             | EndpointUrl
-            | ExpectedHandshake
             | IllegalDiscoveryResponse
             | IllegalIp
             | Json(_) => Self::ProtocolViolation,

--- a/src/input/error.rs
+++ b/src/input/error.rs
@@ -113,7 +113,7 @@ impl StdError for Error {
 
 /// An error returned from the [`dca`] method.
 ///
-/// [`dca`]: crate::input::dca
+/// [`dca`]: crate::input::dca()
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum DcaError {

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -114,16 +114,12 @@ impl SenderExt for WsStream {
 #[inline]
 pub(crate) fn convert_ws_message(message: Option<Message>) -> Result<Option<Event>> {
     Ok(match message {
-        Some(Message::Text(payload)) => match serde_json::from_str(&payload) {
-            Ok(event) => Some(event),
-            Err(why) => {
-                debug!(
-                    "Could not deserialize websocket event, payload: {}, error: {}",
-                    payload, why
-                );
-                None
-            },
-        },
+        Some(Message::Text(payload)) => serde_json::from_str(&payload)
+            .map_err(|e| {
+                debug!("Unexpected JSON {payload:?}.");
+                e
+            })
+            .ok(),
         Some(Message::Binary(bytes)) => {
             return Err(Error::UnexpectedBinaryMessage(bytes));
         },


### PR DESCRIPTION
…erenity-rs#170)

Receiving a new opcode while connecting to a voice channel was causing the connection to fail, while this was handled correctly elsewhere. Unfortunately, Discord added such a payload during every connection.

This PR moves the logging and conversion to no-op (and log) to catch both locations.
yhjuj