### PR TITLE
Gateway: Twilight 0.15 support (serenity-rs#171)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Create a report for any unexpected behaviour
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Songbird version:** (version)
+
+**Rust version (`rustc -V`):** (version)
+
+**Serenity/Twilight version:** (version)
+
+**Output of `ffmpeg -version`, `yt-dlp --version` (if relevant):**
+...
+
+**Description:**
+...
+
+**Steps to reproduce:**
+...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.3.2] - 2023-04-09
+
+This patch release fixes a WS disconnection that would occur when receiving a
+new opcode, which was happening due to Discord sending such an opcode upon
+connecting to a voice channel.
+
+Thanks to the following for their contributions:
+
+- [@Erk-]
+- [@FelixMcFelix]
+
+### Fixed
+
+- [gateway] Songbird would fail if it could not deserialize ws payload ([@Erk-]) [c:752cae7]
+- [docs] Fix compilation due to ambiguous reference ([@FelixMcFelix]) [c:e5d3feb]
+
 ## [0.3.1] — 2023-03-02
 
 This patch release applies some minor fixes, while correcting documentation errors and adjusting some organisaation in the repository.
@@ -420,6 +436,7 @@ We'd also like to thank all users who have contributed to this module in the pas
 - [driver] Handle Voice close codes, prevent Songbird spinning WS threads (#1068) ([@FelixMcFelix]) [c:26c9c91]
 
 <!-- COMPARISONS -->
+[0.3.2]: https://github.com/serenity-rs/songbird/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/serenity-rs/songbird/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/serenity-rs/songbird/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/serenity-rs/songbird/compare/v0.2.1...v0.2.2
@@ -483,6 +500,8 @@ We'd also like to thank all users who have contributed to this module in the pas
 [@wlcx]: https://github.com/wlcx
 
 <!-- COMMITS -->
+[c:e5d3feb]: https://github.com/serenity-rs/songbird/commit/e5d3febb7bfbc6b4b98af3dbf312c23528307544
+[c:752cae7]: https://github.com/serenity-rs/songbird/commit/752cae7a09b25f69ffac110ca3ce4c841d1ec99b
 [c:eedab8f]: https://github.com/serenity-rs/songbird/commit/eedab8f69d1c17125971e290ee8a50fc1adcdffc
 [c:d6c82f5]: https://github.com/serenity-rs/songbird/commit/d6c82f52a6ea876d15a9196de1a7f8a12432407b
 [c:39a6f69]: https://github.com/serenity-rs/songbird/commit/39a6f69f2324b89d17d7200905a9737d057c0d7e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.3.1] — 2023-03-02
+
+This patch release applies some minor fixes, while correcting documentation errors and adjusting some organisaation in the repository.
+
+Thanks to the following for their contributions:
+
+- [@btoschek]
+- [@FelixMcFelix]
+- [@JamesDSource]
+- [@tazz4843]
+
+### Added
+
+- [repo] Repo: Update issue templates ([@FelixMcFelix]) [c:eedab8f]
+
+### Fixed
+
+- [docs] Chore: Fix README.md CI badge (#161) ([@FelixMcFelix]) [c:d6c82f5]
+- [input] Input: Fix read position after seek restart (#154) ([@JamesDSource]) [c:39a6f69]
+- [docs] Docs: Fix wrong docstring for Track::volume (#152) ([@btoschek]) [c:a2f55b7]
+- [docs] Events: Fix typo in docs for VoiceData (#142) ([@tazz4843]) [c:dc53087]
+
 ## [0.3.0] — 2022-07-22 — **Chaffinch**
 
 Abundant and ever-curious, chaffinches are a vibrant and welcome visitor in these spring and summer months.
@@ -16,7 +38,7 @@ Thanks to the following for their contributions:
 - [@wlcx]
 
 ### Upgrade Pathway
-* Tokio v0.2 support has been removed in parity with other Discord -- users must now migrate to v1.x.x.
+* Tokio v0.2 support has been removed in parity with other Discord libraries -- users must now migrate to v1.x.x.
 * Deprecated events (`ClientConnect`, `DriverConnectFailed`, `DriverReconnectFailed` and `SsrcKnown`) have been removed.
  * `ClientConnect` must now be detected using VoiceStateUpdate messages from your main gateway library of choice.
  * The remainder should be replaced with `DriverDisconnect`, and `DriverConnect`/`DriverReconnect`
@@ -398,6 +420,7 @@ We'd also like to thank all users who have contributed to this module in the pas
 - [driver] Handle Voice close codes, prevent Songbird spinning WS threads (#1068) ([@FelixMcFelix]) [c:26c9c91]
 
 <!-- COMPARISONS -->
+[0.3.1]: https://github.com/serenity-rs/songbird/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/serenity-rs/songbird/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/serenity-rs/songbird/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/serenity-rs/songbird/compare/v0.2.0...v0.2.1
@@ -416,6 +439,7 @@ We'd also like to thank all users who have contributed to this module in the pas
 [@acdenisSK]: https://github.com/acdenisSK
 [@Arcterus]: https://github.com/Arcterus
 [@asg051]: https://github.com/asg051
+[@btoschek]: https://github.com/btoschek
 [@clarity0]: https://github.com/clarity0
 [@DasEtwas]: https://github.com/DasEtwas
 [@DoumanAsh]: https://github.com/DoumanAsh
@@ -429,6 +453,7 @@ We'd also like to thank all users who have contributed to this module in the pas
 [@hiratara]: https://github.com/hiratara
 [@indiv0]: https://github.com/indiv0
 [@james7132]: https://github.com/james7132
+[@JamesDSource]: https://github.com/JamesDSource
 [@JellyWX]: https://github.com/JellyWX
 [@jtscuba]: https://github.com/jtscuba
 [@Lakelezz]: https://github.com/Lakelezz
@@ -450,6 +475,7 @@ We'd also like to thank all users who have contributed to this module in the pas
 [@s0lst1ce]: https://github.com/s0lst1ce
 [@Sreyas-Sreelal]: https://github.com/Sreyas-Sreelal
 [@tarcieri]: https://github.com/tarcieri
+[@tazz4843]: https://github.com/tazz4843
 [@tktcorporation]: https://github.com/tktcorporation
 [@vaporox]: https://github.com/vaporox
 [@vilgotf]: https://github.com/vilgotf
@@ -457,6 +483,11 @@ We'd also like to thank all users who have contributed to this module in the pas
 [@wlcx]: https://github.com/wlcx
 
 <!-- COMMITS -->
+[c:eedab8f]: https://github.com/serenity-rs/songbird/commit/eedab8f69d1c17125971e290ee8a50fc1adcdffc
+[c:d6c82f5]: https://github.com/serenity-rs/songbird/commit/d6c82f52a6ea876d15a9196de1a7f8a12432407b
+[c:39a6f69]: https://github.com/serenity-rs/songbird/commit/39a6f69f2324b89d17d7200905a9737d057c0d7e
+[c:a2f55b7]: https://github.com/serenity-rs/songbird/commit/a2f55b7a35539c00e3a75edfb01d1777e8b19741
+[c:dc53087]: https://github.com/serenity-rs/songbird/commit/dc530874462d5d929ecdf087d74a1301fc863981
 [c:bacf681]: https://github.com/serenity-rs/songbird/commit/bacf68146555db018e59e8276d2617c69a9beaa0
 [c:b4ce845]: https://github.com/serenity-rs/songbird/commit/b4ce84546b8e98d696d5b1b37f05c096486cd313
 [c:8dedf3b]: https://github.com/serenity-rs/songbird/commit/8dedf3bf011640edf0834c8e931b8e5ca5b406aa

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ name = "songbird"
 readme = "README.md"
 repository = "https://github.com/serenity-rs/songbird.git"
 rust-version = "1.61"
-version = "0.3.1"
+version = "0.3.2"
 
 [dependencies]
 async-trait = { optional = true, version = "0.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ tokio-tungstenite = { optional = true, version = "0.18" }
 tokio-util = { features = ["io"], optional = true, version = "0.7" }
 tracing = { version = "0.1", features = ["log"] }
 tracing-futures = "0.2"
-twilight-gateway = { default-features = false, optional = true, version = "0.14.0" }
-twilight-model = { default-features = false, optional = true, version = "0.14.0" }
+twilight-gateway = { default-features = false, optional = true, version = "0.15.0" }
+twilight-model = { default-features = false, optional = true, version = "0.15.0" }
 typemap_rev = { optional = true, version = "0.3" }
 url = { optional = true, version = "2" }
 uuid = { features = ["v4"], optional = true, version = "1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ name = "songbird"
 readme = "README.md"
 repository = "https://github.com/serenity-rs/songbird.git"
 rust-version = "1.61"
-version = "0.3.0"
+version = "0.3.1"
 
 [dependencies]
 async-trait = { optional = true, version = "0.1" }

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Songbird's logo is based upon the copyright-free image ["Black-Capped Chickadee"
 [audiopus]: https://github.com/lakelezz/audiopus
 [according to the installation instructions on the main repo]: https://github.com/yt-dlp/yt-dlp#installation
 
-[build badge]: https://img.shields.io/github/workflow/status/serenity-rs/songbird/CI?style=flat-square
+[build badge]: https://img.shields.io/github/actions/workflow/status/serenity-rs/songbird/ci.yml?branch=current&style=flat-square
 [build]: https://github.com/serenity-rs/songbird/actions
 
 [docs-badge]: https://img.shields.io/badge/docs-current-4d76ae.svg?style=flat-square

--- a/examples/twilight/Cargo.toml
+++ b/examples/twilight/Cargo.toml
@@ -11,10 +11,10 @@ symphonia = { features = ["aac", "mp3", "isomp4", "alac"], version = "0.5.2" }
 tracing = "0.1"
 tracing-subscriber = "0.2"
 tokio = { features = ["macros", "rt-multi-thread", "sync"], version = "1" }
-twilight-gateway = "0.14"
-twilight-http = "0.14"
-twilight-model = "0.14"
-twilight-standby = "0.14"
+twilight-gateway = "0.15"
+twilight-http = "0.15"
+twilight-model = "0.15"
+twilight-standby = "0.15"
 
 [dependencies.songbird]
 default-features = false

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -31,6 +31,8 @@ pub use mix_mode::MixMode;
 pub use test_config::*;
 
 #[cfg(feature = "builtin-queue")]
+use crate::tracks;
+#[cfg(feature = "builtin-queue")]
 use crate::tracks::TrackQueue;
 use crate::{
     events::EventData,

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,7 +11,7 @@ pub use simd_json::Error as JsonError;
 #[cfg(feature = "gateway")]
 use std::{error::Error, fmt};
 #[cfg(feature = "twilight")]
-use twilight_gateway::{cluster::ClusterCommandError, shard::CommandError};
+use twilight_gateway::error::SendError;
 
 #[cfg(feature = "gateway")]
 #[derive(Debug)]
@@ -50,11 +50,8 @@ pub enum JoinError {
     /// Serenity-specific WebSocket send error.
     Serenity(TrySendError<InterMessage>),
     #[cfg(feature = "twilight")]
-    /// Twilight-specific WebSocket send error returned when using a shard cluster.
-    TwilightCluster(ClusterCommandError),
-    #[cfg(feature = "twilight")]
-    /// Twilight-specific WebSocket send error when explicitly using a single shard.
-    TwilightShard(CommandError),
+    /// Twilight-specific WebSocket send error when a message fails to send over websocket.
+    Twilight(SendError),
 }
 
 #[cfg(feature = "gateway")]
@@ -96,9 +93,7 @@ impl fmt::Display for JoinError {
             #[cfg(feature = "serenity")]
             JoinError::Serenity(e) => e.fmt(f),
             #[cfg(feature = "twilight")]
-            JoinError::TwilightCluster(e) => e.fmt(f),
-            #[cfg(feature = "twilight")]
-            JoinError::TwilightShard(e) => e.fmt(f),
+            JoinError::Twilight(e) => e.fmt(f),
         }
     }
 }
@@ -116,9 +111,7 @@ impl Error for JoinError {
             #[cfg(feature = "serenity")]
             JoinError::Serenity(e) => e.source(),
             #[cfg(feature = "twilight")]
-            JoinError::TwilightCluster(e) => e.source(),
-            #[cfg(feature = "twilight")]
-            JoinError::TwilightShard(e) => e.source(),
+            JoinError::Twilight(e) => e.source(),
         }
     }
 }
@@ -131,16 +124,9 @@ impl From<TrySendError<InterMessage>> for JoinError {
 }
 
 #[cfg(all(feature = "twilight", feature = "gateway"))]
-impl From<CommandError> for JoinError {
-    fn from(e: CommandError) -> Self {
-        JoinError::TwilightShard(e)
-    }
-}
-
-#[cfg(all(feature = "twilight", feature = "gateway"))]
-impl From<ClusterCommandError> for JoinError {
-    fn from(e: ClusterCommandError) -> Self {
-        JoinError::TwilightCluster(e)
+impl From<SendError> for JoinError {
+    fn from(e: SendError) -> Self {
+        JoinError::Twilight(e)
     }
 }
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -26,9 +26,8 @@ use serenity::{
 };
 use std::sync::Arc;
 use tokio::sync::Mutex;
+#[cfg(feature = "serenity")]
 use tracing::debug;
-#[cfg(feature = "twilight")]
-use twilight_gateway::Cluster;
 #[cfg(feature = "twilight")]
 use twilight_model::gateway::event::Event as TwilightEvent;
 
@@ -88,7 +87,7 @@ impl Songbird {
     /// [`process`].
     ///
     /// [`process`]: Songbird::process
-    pub fn twilight<U>(cluster: Arc<Cluster>, user_id: U) -> Self
+    pub fn twilight<U>(cluster: Arc<crate::shards::TwilightMap>, user_id: U) -> Self
     where
         U: Into<UserId>,
     {
@@ -103,17 +102,21 @@ impl Songbird {
     /// [`process`].
     ///
     /// [`process`]: Songbird::process
-    pub fn twilight_from_config<U>(cluster: Arc<Cluster>, user_id: U, config: Config) -> Self
+    pub fn twilight_from_config<U>(
+        sender_map: Arc<crate::shards::TwilightMap>,
+        user_id: U,
+        config: Config,
+    ) -> Self
     where
         U: Into<UserId>,
     {
         Self {
             client_data: OnceCell::with_value(ClientData {
-                shard_count: cluster.config().shard_scheme().total(),
+                shard_count: sender_map.shard_count(),
                 user_id: user_id.into(),
             }),
             calls: DashMap::new(),
-            sharder: Sharder::TwilightCluster(cluster),
+            sharder: Sharder::Twilight(sender_map),
             config: config.initialise_disposer().into(),
         }
     }
@@ -370,8 +373,8 @@ impl Songbird {
     pub async fn process(&self, event: &TwilightEvent) {
         match event {
             TwilightEvent::VoiceServerUpdate(v) => {
-                let id = GuildId::from(v.guild_id);
-                let call = self.get(id);
+                let guild_id = GuildId::from(v.guild_id);
+                let call = self.get(guild_id);
 
                 if let Some(call) = call {
                     let mut handler = call.lock().await;


### PR DESCRIPTION
This patch changes around quite a few things.
The main entrypoint for twilight besides process will now be the
TwilightMap which concists of command senders for each shard.

This simplifies parts of the code as there is not any difference
between shards and clusters anymore.